### PR TITLE
Properly handle transaction errors

### DIFF
--- a/src/PGOCaml_generic.ml
+++ b/src/PGOCaml_generic.ml
@@ -1269,6 +1269,7 @@ let transact conn ?isolation ?access ?deferrable f =
        return r
     )
     (fun e ->
+       ping conn >>= fun () ->
        rollback conn >>= fun () ->
        fail e
     )


### PR DESCRIPTION
When an error occurs inside a transaction we need to rsync with the
database before proceeding with the rollback. Not doing that will leave
the connection in a hung state.