### PR TITLE
Fix timezone in timestamptz_of_string

### DIFF
--- a/src/PGOCaml_generic.ml
+++ b/src/PGOCaml_generic.ml
@@ -1715,7 +1715,7 @@ let timestamptz_of_string str =
   let tz = match tz with
     | None -> Time_Zone.Local (* best guess? *)
     | Some tz ->
-	let sgn = match tz.[0] with '+' -> 1 | '-' -> 0 | _ -> assert false in
+	let sgn = match tz.[0] with '+' -> 1 | '-' -> -1 | _ -> assert false in
 	let mag = int_of_string (String.sub tz 1 2) in
 	Time_Zone.UTC_Plus (sgn * mag) in
   cal, tz


### PR DESCRIPTION
This fixes a small issue with timezone interpretation in `timestamptz_of_string`. Negative timezone offsets were multiplied by 0, thus becoming 0 (UTC). For example:

```
# snd (PGOCaml.timestamptz_of_string "2016-05-16 11:30:08.326698-04") ;;
- : CalendarLib.Time_Zone.t = CalendarLib.Time_Zone.UTC_Plus 0
```