### PR TITLE
Fixed IPv6 connections

### DIFF
--- a/src/PGOCaml_generic.ml
+++ b/src/PGOCaml_generic.ml
@@ -932,34 +932,19 @@ let connect ?host ?port ?user ?password ?database
 	with Not_found | Failure _ -> 5432 in
 
   (* Make the socket address. *)
-  let sockaddr =
+  let sockaddrs =
     match host with
     | Some h when
         String.length h > 0 && String.get h 0 = '/' ->
-      pgsql_socket h port
+      [pgsql_socket h port]
     | Some hostname ->
-	(try
-	   let hostent = Unix.gethostbyname hostname in
-	   let domain = hostent.Unix.h_addrtype in
-	   match domain with
-	   | Unix.PF_INET | Unix.PF_INET6 ->
-	       (* Choose a random address from the list. *)
-	       let addrs = hostent.Unix.h_addr_list in
-	       let len = Array.length addrs in
-	       if len <= 0 then
-		 raise (Error ("PGOCaml: unknown host: " ^ hostname));
-	       let i = Random.int len in
-	       let addr = addrs.(i) in
-	       Unix.ADDR_INET (addr, port)
-	   | Unix.PF_UNIX ->
-	       (* Would we trust a pathname returned through DNS? *)
-	       raise (Error "PGOCaml: DNS returned PF_UNIX record")
-	 with
-	   Not_found ->
-	     raise (Error ("PGOCaml: unknown host: " ^ hostname))
-	);
+       let addrs = Unix.getaddrinfo hostname (sprintf "%d" port) [Unix.AI_SOCKTYPE(Unix.SOCK_STREAM)] in
+       if addrs = [] then 
+	 raise (Error ("PGOCaml: unknown host: " ^ hostname))
+       else
+	 List.map (fun {Unix.ai_addr = sockaddr; _} -> sockaddr) addrs
     | None -> (* Unix domain socket. *)
-      pgsql_socket unix_domain_socket_dir port in
+      [pgsql_socket unix_domain_socket_dir port] in
 
   (* Create a universally unique identifier for this connection.  This
    * is mainly for debugging and profiling.
@@ -983,8 +968,20 @@ let connect ?host ?port ?user ?password ?database
       ((Unix.times ()).Unix.tms_utime) in
   let uuid = Digest.to_hex (Digest.string uuid) in
 
+  let sock_channels =
+    let rec create_sock_channels sockaddrs =
+      match sockaddrs with
+	[] -> 
+	  raise (Error ("PGOCaml: Could not connect to database"))
+      | sockaddr :: sockaddrs ->
+	 try
+	   open_connection sockaddr 
+	 with
+	   Unix.Unix_error _ -> create_sock_channels sockaddrs in
+    create_sock_channels sockaddrs in
+    
   let do_connect () =
-    open_connection sockaddr >>= fun (ichan, chan) ->
+    sock_channels >>= fun (ichan, chan) ->
 
     (* Create the connection structure. *)
     let conn = { ichan = ichan;


### PR DESCRIPTION
I have replaced Unix.gethostbyname with Unix.getaddrinfo to make it possible to connect both over IPv4 and IPv6.