### PR TITLE
annotate all metaquotations with metaloc

### DIFF
--- a/tests_ppx/test_ppx.ml
+++ b/tests_ppx/test_ppx.ml
@@ -7,6 +7,9 @@ salary int4 not null,
 email text
 )"]
 
+let employee_exists dbh ?email n =
+  [%pgsql dbh "SELECT EXISTS (SELECT 1 FROM employees WHERE name = $n AND email = $?email AND email = $email)"]
+
 let () =
   let dbh = PGOCaml.connect () in
 


### PR DESCRIPTION
This PR carefully annotates the entire syntax tree with useful locations, as `ppx_tools_versioned.metaquot` doesn't actually behave as the documentation of `ppx_tools.metaquot` indicates.