### PR TITLE
fix treatment of socket path passed in env variable PGHOST

### DIFF
--- a/src/PGOCaml_generic.ml
+++ b/src/PGOCaml_generic.ml
@@ -1006,25 +1006,28 @@ let describe_connection ?host ?port ?user ?password ?database
       try Sys.getenv "PGDATABASE"
       with Not_found -> user in
 
-  (* Hostname and port number. *)
+  (* Socket path or Hostname *)
   let host =
+    let host_or_socket s =
+      if String.length s > 0 && s.[0] = '/'
+      then `Unix_domain_socket_dir s
+      else `Hostname s in
     match (host, unix_domain_socket_dir) with
     | (Some _), (Some _) ->
       raise (Failure "describe_connection: it's invalid to specify both a HOST and a unix domain socket directory")
-    | (Some s), None when String.length s > 0 && String.get s 0 = '/' ->
-      `Unix_domain_socket_dir s
     | (Some s), None ->
-      `Hostname s
+       host_or_socket s
     | None, (Some s) ->
       `Unix_domain_socket_dir s
     | None, None ->
-      try
-        `Hostname (Sys.getenv "PGHOST")
-      with
-        Not_found -> (* fall back on Unix domain socket. *)
-          `Unix_domain_socket_dir PGOCaml_config.default_unix_domain_socket_dir
+       try
+         host_or_socket (Sys.getenv "PGHOST")
+       with
+         Not_found -> (* fall back on Unix domain socket. *)
+         `Unix_domain_socket_dir PGOCaml_config.default_unix_domain_socket_dir
   in
 
+  (* get port number *)
   let port =
     match port with
     | Some port -> port


### PR DESCRIPTION
When a socket path is passed in PGHOST it is treated as a hostname.
This PR should fix that behaviour.