### PR TITLE
OCaml 5 compatibility: add camlp-streams as a dependency

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -19,7 +19,7 @@
 (library
   (name PGOCaml)
   (public_name pgocaml)
-  (libraries calendar csv hex re rresult sexplib unix)
+  (libraries calendar csv hex re rresult sexplib unix camlp-streams)
   (preprocess
     (pps ppx_sexp_conv ppx_deriving.show))
   (wrapped false)


### PR DESCRIPTION
This PR restores compatibility with OCaml 5.0 by adding `camlp-streams` as an explicit dependency of `pgocaml`.