### PR TITLE
scram-sha-256 authentication

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -19,8 +19,10 @@
 (library
   (name PGOCaml)
   (public_name pgocaml)
-  (libraries calendar csv hex re rresult sexplib unix camlp-streams)
-  (preprocess
-    (pps ppx_sexp_conv ppx_deriving.show))
+  (libraries calendar csv hex re rresult sexplib unix camlp-streams
+    (select scram.ml from
+      (base64 digestif -> scram.optional.ml)
+      (-> scram.dummy.ml)))
+  (preprocess (pps ppx_sexp_conv ppx_deriving.show))
   (wrapped false)
-  (modules PGOCaml_aux PGOCaml PGOCaml_generic PGOCaml_config))
+  (modules scram PGOCaml_aux PGOCaml PGOCaml_generic PGOCaml_config))

--- a/src/scram.dummy.ml
+++ b/src/scram.dummy.ml
@@ -1,0 +1,10 @@
+let scram_sha_256_mechanism = "SCRAM-SHA-256"
+
+let client_first_message ?user:_ mechanisms =
+  if List.mem scram_sha_256_mechanism mechanisms then
+    Error "PGOCaml: SCRAM-SHA-256 authentication requires base64 and digestif optional dependencies of pgocaml"
+  else
+    Error (Format.sprintf "PGOCaml: None of %s mechanism is implemented" (String.concat ", " mechanisms))
+
+let client_final_message ?user:_ ~password:_ ~client_info:_ _msg =
+  Error "PGOCaml: SASL authentication not implemented"

--- a/src/scram.mli
+++ b/src/scram.mli
@@ -1,0 +1,2 @@
+val client_first_message: ?user:string -> string list -> (string * string * (string * string), string) result
+val client_final_message: ?user: string -> password:string -> client_info:(string * string) -> string -> (string * string, string) result

--- a/src/scram.optional.ml
+++ b/src/scram.optional.ml
@@ -1,0 +1,71 @@
+let generate_nonce =
+  let init_done = ref false in fun n ->
+    if not !init_done then (Random.self_init (); init_done := true);
+    let char () =
+      let i = Random.int 62 in
+      if i < 10 then Char.chr (i+48)
+      else if i < 36 then Char.chr (i+55)
+      else Char.chr (i+61) in
+    String.init n (fun _ -> char ())
+
+let scram_sha_256_mechanism = "SCRAM-SHA-256"
+
+let client_first_message ?(user="") mechanisms =
+  if List.mem scram_sha_256_mechanism mechanisms then
+    let gs2_header = "n,," in (* no channel binding *)
+    let nonce = generate_nonce 20 in
+    let s = Format.sprintf "%sn=%s,r=%s" gs2_header user nonce in
+    Ok (s, scram_sha_256_mechanism, (nonce, gs2_header))
+  else
+    (* todo: implement scram-sha-256-plus when ssl is available *)
+    Error (Format.sprintf "PGOCaml: None of %s mechanism is implemented" (String.concat ", " mechanisms))
+
+let xor a b =
+  if String.length b <> String.length a then invalid_arg "xor: both strings must be of same lengths";
+  String.mapi (fun i c -> Char.(chr (code c lxor code (String.get b i)))) a
+
+let sha256 msg = Digestif.SHA256.(to_raw_string @@ digest_string msg)
+let hmac ~key msg = Digestif.SHA256.(to_raw_string @@ hmac_string ~key msg)
+
+let hi ~password:key ~salt ~count =
+  if count <= 0 then invalid_arg "count must be a positive integer" ;
+  let rec aux acc x = function
+    | 1 -> x
+    | i ->
+      let acc = hmac ~key acc in
+      aux acc (xor x acc) (i-1) in
+  let start = hmac ~key (salt ^ "\000\000\000\001") in
+  aux start start count
+
+let proof ~user ~password ~client_nonce ~server_nonce ~salt64 ~gs2_header64 ~count =
+  let salt = Base64.decode_exn salt64 in
+  let salted_password = hi ~password ~salt ~count in
+  let client_key = hmac ~key:salted_password "Client Key" in
+  let stored_key = sha256 client_key in
+  let auth_message = Format.sprintf "n=%s,r=%s,r=%s,s=%s,i=%d,c=%s,r=%s"
+      user client_nonce server_nonce salt64 count gs2_header64 server_nonce in
+  let client_signature = hmac ~key:stored_key auth_message in
+  let client_proof = xor client_key client_signature in
+  let client_proof64 = Base64.encode_exn client_proof in
+  let server_key = hmac ~key:salted_password "Server Key" in
+  let server_signature = hmac ~key:server_key auth_message in
+  let server_signature64 = Base64.encode_exn server_signature in
+  client_proof64, server_signature64
+
+let client_final_message ?(user="") ~password ~client_info s =
+  let client_nonce, gs2_header = client_info in
+  let l = List.filter_map (fun s -> match String.index_opt s '=' with
+      | None -> None
+      | Some i -> Some (String.sub s 0 i, String.sub s (i+1) (String.length s -i-1))
+    ) @@ String.split_on_char ',' s in
+  let err = Error "PGOCaml: server SASL authentication message not understood" in
+  match List.assoc_opt "r" l, List.assoc_opt "s" l, List.assoc_opt "i" l with
+  | Some server_nonce, Some salt64, Some count ->
+    if String.starts_with ~prefix:client_nonce server_nonce then
+      let count = int_of_string count in
+      let gs2_header64 = Base64.encode_exn gs2_header in
+      let proof, signature = proof ~user ~password ~client_nonce ~server_nonce ~salt64 ~gs2_header64 ~count in
+      let s = Format.sprintf "c=%s,r=%s,p=%s" gs2_header64 server_nonce proof in
+      Ok (s, signature)
+    else err
+  | _ -> err


### PR DESCRIPTION
Since version 14 of postgresql, the default password authentication is done via scram-sha-256 and md5 cannot be used even when set in pg_hba.conf (unless the password_encryption config is changed to md5 in postgresql.conf).

This PR implements the scram algorithm [RFC7677](https://datatracker.ietf.org/doc/html/rfc7677) [FRC5802](https://datatracker.ietf.org/doc/html/rfc5802) that is used in the [postgresql backend](https://www.postgresql.org/docs/current/sasl-authentication.html). 
For this the `base64` and `digestif` (for hmac and sha256) dependencies are required.  
To avoid adding unnecessay dependencies for users using postgreql in trust mode, these dependencies are put as optional and a dummy implementation of scram is then given that fails on scram-sha-256 authentication messages. 